### PR TITLE
Hydrator loader fix

### DIFF
--- a/src/DependencyInjection/Pimple/HydratorServiceProvider.php
+++ b/src/DependencyInjection/Pimple/HydratorServiceProvider.php
@@ -48,7 +48,7 @@ class HydratorServiceProvider implements ServiceProviderInterface
     {
         $container['hydrator_dir'] = \sys_get_temp_dir().'/serializer/hydrators';
         $container['hydrator_namespace'] = 'App\\Hydrator';
-        $container['generation_strategy'] = HydratorCompiler::AUTOGENERATE_ALWAYS;
+        $container['generation_strategy'] = HydratorLoader::COMPILE_IF_NOT_EXISTS;
         $container['property_group_enabled'] = false;
         $container['max_depth_check_enabled'] = false;
 

--- a/src/DependencyInjection/Pimple/HydratorServiceProvider.php
+++ b/src/DependencyInjection/Pimple/HydratorServiceProvider.php
@@ -111,7 +111,6 @@ class HydratorServiceProvider implements ServiceProviderInterface
 
         $container[HydratorCompilerInterface::class] = function ($container) {
             return new HydratorCompiler(
-                $container[Configuration::class],
                 $container[HydratorCodeGenerator::class],
                 $container[HydratorCodeWriter::class]
             );

--- a/src/HydratorCompiler.php
+++ b/src/HydratorCompiler.php
@@ -22,14 +22,23 @@ use TSantos\Serializer\Metadata\ClassMetadata;
  */
 class HydratorCompiler implements HydratorCompilerInterface
 {
-    const AUTOGENERATE_NEVER = 1;
-    const AUTOGENERATE_ALWAYS = 2;
-    const AUTOGENERATE_FILE_NOT_EXISTS = 3;
+    /**
+     * @deprecated Constant moved to HydratorLoader and will be removed from HydratorCompiler on version 5.0
+     * @see \TSantos\Serializer\HydratorLoader::COMPILE_NEVER
+     */
+    const AUTOGENERATE_NEVER = HydratorLoader::COMPILE_NEVER;
 
     /**
-     * @var Configuration
+     * @deprecated Constant moved to HydratorLoader and will be removed from HydratorCompiler on version 5.0
+     * @see \TSantos\Serializer\HydratorLoader::COMPILE_ALWAYS
      */
-    private $configuration;
+    const AUTOGENERATE_ALWAYS = HydratorLoader::COMPILE_ALWAYS;
+
+    /**
+     * @deprecated Constant moved to HydratorLoader and will be removed from HydratorCompiler on version 5.0
+     * @see \TSantos\Serializer\HydratorLoader::COMPILE_IF_NOT_EXISTS
+     */
+    const AUTOGENERATE_FILE_NOT_EXISTS = HydratorLoader::COMPILE_IF_NOT_EXISTS;
 
     /**
      * @var HydratorCodeGenerator
@@ -44,49 +53,18 @@ class HydratorCompiler implements HydratorCompilerInterface
     /**
      * Compiler constructor.
      *
-     * @param Configuration         $configuration
      * @param HydratorCodeGenerator $generator
      * @param HydratorCodeWriter    $writer
      */
-    public function __construct(Configuration $configuration, HydratorCodeGenerator $generator, HydratorCodeWriter $writer)
+    public function __construct(HydratorCodeGenerator $generator, HydratorCodeWriter $writer)
     {
-        $this->configuration = $configuration;
         $this->generator = $generator;
         $this->writer = $writer;
     }
 
     public function compile(ClassMetadata $classMetadata): void
     {
-        $filename = $this->configuration->getFilename($classMetadata);
-
-        switch ($this->configuration->getGenerationStrategy()) {
-            case self::AUTOGENERATE_NEVER:
-                requireHydrator($filename);
-                break;
-
-            case self::AUTOGENERATE_ALWAYS:
-                $this->generate($classMetadata);
-                requireHydrator($filename);
-                break;
-
-            case self::AUTOGENERATE_FILE_NOT_EXISTS:
-                if (!\file_exists($filename)) {
-                    $this->generate($classMetadata);
-                }
-                requireHydrator($filename);
-                break;
-        }
-    }
-
-    private function generate(ClassMetadata $classMetadata)
-    {
         $code = $this->generator->generate($classMetadata);
         $this->writer->write($classMetadata, $code);
     }
-}
-
-function requireHydrator(string $filename): void
-{
-    /** @noinspection PhpIncludeInspection */
-    require_once $filename;
 }

--- a/src/HydratorLoader.php
+++ b/src/HydratorLoader.php
@@ -99,6 +99,13 @@ class HydratorLoader implements HydratorLoaderInterface
             return $this->hydrators[$class] = $this->factory->newInstance($classMetadata);
         }
 
+        $this->compileAndLoad($classMetadata);
+
+        return $this->hydrators[$class] = $this->factory->newInstance($classMetadata);
+    }
+
+    private function compileAndLoad(ClassMetadata $classMetadata): void
+    {
         $filename = $this->configuration->getFilename($classMetadata);
 
         switch ($this->configuration->getGenerationStrategy()) {
@@ -118,8 +125,6 @@ class HydratorLoader implements HydratorLoaderInterface
                 requireHydrator($filename);
                 break;
         }
-
-        return $this->hydrators[$class] = $this->factory->newInstance($classMetadata);
     }
 }
 

--- a/tests/HydratorCompilerTest.php
+++ b/tests/HydratorCompilerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TSantos Serializer package.
+ *
+ * (c) Tales Santos <tales.augusto.santos@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\TSantos\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use TSantos\Serializer\HydratorCodeGenerator;
+use TSantos\Serializer\HydratorCodeWriter;
+use TSantos\Serializer\HydratorCompiler;
+use TSantos\Serializer\Metadata\ClassMetadata;
+
+/**
+ * Class HydratorCompilerTest.
+ *
+ * @author Tales Santos <tales.augusto.santos@gmail.com>
+ */
+class HydratorCompilerTest extends TestCase
+{
+    /** @test */
+    public function it_can_compile_a_class()
+    {
+        $classMetadata = $this->createMock(ClassMetadata::class);
+
+        $generator = $this->createMock(HydratorCodeGenerator::class);
+        $generator
+            ->expects($this->once())
+            ->method('generate')
+            ->with($classMetadata)
+            ->willReturn('<?php MyHydrator {}');
+
+        $writer = $this->createMock(HydratorCodeWriter::class);
+        $writer
+            ->expects($this->once())
+            ->method('write')
+            ->with($classMetadata, '<?php MyHydrator {}');
+
+        $compiler = new HydratorCompiler($generator, $writer);
+        $compiler->compile($classMetadata);
+    }
+}


### PR DESCRIPTION
The logic of deciding if the hydrator should be compiled was moved from `HydratorCompiler` class to `HydratorLoader` class.

This was necessary to allow us to compile hydrators regardless the builder is configured to compile hydrator or not via `HydratorCompiler` constants.